### PR TITLE
fix: ignore plaintext files

### DIFF
--- a/registry/ignore.toml
+++ b/registry/ignore.toml
@@ -29,6 +29,7 @@ filetypes = [
   "snacks_terminal",
   "startuptime",
   "TelescopePrompt",
+  "text",
   "toggleterm",
   "Trouble",
   "undotree",


### PR DESCRIPTION
I noticed that Arborist was searching for a parser every time I opened a plaintext file (which can never have one, since it's unstructured by definition).  I added that to my ignore list when I initialize Arborist, but it seems like it might be worth adding to the defaults here.