### PR TITLE
Prevent duplicate git/build processes during parser installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All options and their defaults:
 | `ensure_installed` | `{}`      | Additional parsers to install eagerly at startup        |
 | `ignore`           | `{}`      | Extra filetypes to skip (merged with registry defaults) |
 | `overrides`        | `{}`      | Extra parsers not in the registry                       |
+| `concurrency`      | `nil`     | Max repos to clone/build in parallel (`nil` = unlimited) |
 
 ## Parsers and Queries
 

--- a/lua/arborist/compile.lua
+++ b/lua/arborist/compile.lua
@@ -99,7 +99,8 @@ end
 --- @param info arborist.ParserInfo
 --- @param cache_dir string
 --- @param callback fun(err: string?, path: string?)
-function M.clone_repo(info, cache_dir, callback)
+--- @param on_pid? fun(pid: integer)  called with the git process PID right after clone starts
+function M.clone_repo(info, cache_dir, callback, on_pid)
   local url = info.url
   local revision = info.revision -- optional pin
   local name = url:match("([^/]+)$")
@@ -148,7 +149,7 @@ function M.clone_repo(info, cache_dir, callback)
     local args = revision
         and { "git", "clone", "--quiet", clone_url, clone_dest }
       or { "git", "clone", "--depth", "1", "--single-branch", "--quiet", clone_url, clone_dest }
-    vim.system(args, {}, function(r)
+    local handle = vim.system(args, {}, function(r)
       if r.code ~= 0 then
         if on_fail then on_fail() else finish_err("clone failed: " .. clone_url .. "\n" .. cmd_output(r)) end
         return
@@ -161,6 +162,7 @@ function M.clone_repo(info, cache_dir, callback)
         finish_path(clone_dest)
       end
     end)
+    if on_pid then on_pid(handle.pid) end
   end
 
   if info.fallback_url then

--- a/lua/arborist/config.lua
+++ b/lua/arborist/config.lua
@@ -8,6 +8,7 @@
 --- @field ensure_installed string[] Additional parsers to install eagerly at startup
 --- @field ignore string[] Extra filetypes to ignore (merged with registry defaults)
 --- @field overrides table<string, {url: string, location?: string}> Extra parser overrides
+--- @field concurrency integer? Max parallel repo installs (nil = unlimited)
 
 --- @type arborist.Config
 local defaults = {
@@ -22,6 +23,9 @@ local defaults = {
   ensure_installed = {},
   ignore = {},
   overrides = {},
+  -- Maximum number of repos to clone/build in parallel. nil means unlimited.
+  -- Set to 1 to install one at a time (useful on metered connections).
+  concurrency = nil,
 }
 
 local valid_cadence = { daily = true, weekly = true, manual = true }

--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -96,12 +96,17 @@ function M.setup(opts)
     end
   end
 
+  local ensuring = {} --- @type table<string, boolean>
+
   --- Install a parser for a lang if needed, then enable on all matching buffers.
   --- @param lang string
   local function ensure_parser(lang)
     if install.should_skip(lang) then return end
     if parser_loaded(lang) then enable_bufs(lang); return end
+    if ensuring[lang] then return end
+    ensuring[lang] = true
     install.install(lang, function(err)
+      ensuring[lang] = nil
       if err then return end
       vim.schedule(function() enable_bufs(lang) end)
     end, { silent = true })

--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -126,6 +126,7 @@ function M.setup(opts)
     for _, lang in ipairs(to_install) do
       if install.should_skip(lang) then -- skip
       elseif parser_loaded(lang) then enable_bufs(lang)
+      elseif install.is_installing(lang) then
       else needed[#needed + 1] = lang end
     end
 

--- a/lua/arborist/install.lua
+++ b/lua/arborist/install.lua
@@ -199,21 +199,30 @@ function M.install_batch(langs, callback, opts)
     if groups_remaining == 0 then callback(results) end
   end
 
-  -- Clone each unique repo in parallel, then build parsers sequentially.
-  for _, url in ipairs(group_order) do
+  -- Clone each unique repo, then build parsers sequentially within each repo.
+  -- Concurrency limits how many repos are processed in parallel.
+  local max_concurrent = config.values.concurrency or math.huge
+  local active_count = 0
+  local pending_urls = {} --- @type string[]
+
+  local function start_group(url)
+    active_count = active_count + 1
     local parsers = groups[url]
 
     compile.clone_repo(parsers[1].info, repo_cache, function(err, path)
       if err then
         for _, p in ipairs(parsers) do results[p.lang] = err end
+        active_count = active_count - 1
         group_done()
+        if #pending_urls > 0 then start_group(table.remove(pending_urls, 1)) end
         return
       end
 
-      -- Build parsers for this repo one at a time
       local function build_next(i)
         if i > #parsers then
+          active_count = active_count - 1
           group_done()
+          if #pending_urls > 0 then start_group(table.remove(pending_urls, 1)) end
           return
         end
         local p = parsers[i]
@@ -227,6 +236,14 @@ function M.install_batch(langs, callback, opts)
     end, function(git_pid)
       for _, p in ipairs(parsers) do update_lock_pid(p.lang, git_pid) end
     end)
+  end
+
+  for _, url in ipairs(group_order) do
+    if active_count < max_concurrent then
+      start_group(url)
+    else
+      pending_urls[#pending_urls + 1] = url
+    end
   end
 end
 

--- a/lua/arborist/install.lua
+++ b/lua/arborist/install.lua
@@ -33,6 +33,54 @@ function M.init(dirs)
   repo_cache = dirs.repo_cache
 end
 
+local function lock_path(lang)
+  return repo_cache .. "/" .. lang .. ".installing"
+end
+
+--- Check whether a parser install is in progress, possibly from another
+--- Neovim instance. Reads a PID file written at install start; if the
+--- PID is no longer alive the lock is stale and gets cleaned up.
+--- @param lang string
+--- @return boolean
+function M.is_installing(lang)
+  local path = lock_path(lang)
+  local f = io.open(path, "r")
+  if not f then return false end
+  local pid = tonumber(f:read("*a"))
+  f:close()
+  if not pid then os.remove(path); return false end
+  local alive = vim.uv.kill(pid, 0) == 0
+  if not alive then os.remove(path); return false end
+  return true
+end
+
+--- Atomically claim the install slot using O_CREAT|O_EXCL.
+--- Returns false if another process already holds the lock.
+--- @param lang string
+--- @return boolean
+local function mark_installing(lang)
+  local fd = vim.uv.fs_open(lock_path(lang), "wx", 420)
+  if not fd then return false end
+  vim.uv.fs_write(fd, tostring(vim.fn.getpid()), 0)
+  vim.uv.fs_close(fd)
+  return true
+end
+
+--- Overwrite the lock file with a new PID (e.g. the git clone process).
+--- Called after the clone starts so the lock survives Vim exiting.
+--- @param lang string
+--- @param pid integer
+local function update_lock_pid(lang, pid)
+  local fd = vim.uv.fs_open(lock_path(lang), "w", 420)
+  if not fd then return end
+  vim.uv.fs_write(fd, tostring(pid), 0)
+  vim.uv.fs_close(fd)
+end
+
+local function unmark_installing(lang)
+  pcall(os.remove, lock_path(lang))
+end
+
 --- Mark filetypes to ignore. Merges with existing.
 --- @param list string[]
 function M.set_ignore(list)
@@ -65,6 +113,7 @@ local function build_parser(repo_path, lang, info, opts, callback)
   local function finish(err, mode)
     if err and opts.silent then ignore[lang] = true end
     if mode then lock.record(lang, mode) end
+    unmark_installing(lang)
     callback(err)
   end
 
@@ -115,6 +164,17 @@ end
 function M.install_batch(langs, callback, opts)
   opts = opts or {}
 
+  -- Skip langs already being installed by another process; atomically claim the rest.
+  -- is_installing cleans up stale locks (dead PIDs); mark_installing uses O_EXCL
+  -- so concurrent Neovim instances can't both claim the same lang.
+  local active = {}
+  for _, lang in ipairs(langs) do
+    if not M.is_installing(lang) and mark_installing(lang) then
+      active[#active + 1] = lang
+    end
+  end
+  langs = active
+
   -- Resolve all parsers and group by repo URL
   --- @type table<string, {lang: string, info: arborist.ParserInfo}[]>
   local groups = {}
@@ -164,6 +224,8 @@ function M.install_batch(langs, callback, opts)
       end
 
       build_next(1)
+    end, function(git_pid)
+      for _, p in ipairs(parsers) do update_lock_pid(p.lang, git_pid) end
     end)
   end
 end

--- a/registry/ignore.toml
+++ b/registry/ignore.toml
@@ -29,6 +29,7 @@ filetypes = [
   "snacks_terminal",
   "startuptime",
   "TelescopePrompt",
+  "text",
   "toggleterm",
   "Trouble",
   "undotree",


### PR DESCRIPTION
## Prevent duplicate git/build processes during parser installation

Three related fixes for a class of bug where multiple git clone/fetch/build processes end up running for the same parser simultaneously. This happens in two distinct scenarios and one contributing factor.

### Problem 1: same Neovim instance, multiple events

`FileType` and `BufReadPost` both fire when a buffer is opened, and both call `ensure_parser`. With no in-flight guard, two `install.install()` calls would race for the same lang within the same Neovim session, each spawning its own git clone. Fixed by adding an `ensuring` table in `init.lua` that tracks in-progress installs and skips subsequent calls for the same lang until the first completes.

### Problem 2: Neovim restarted during a slow install

When you restart Neovim while a git clone is running, the git process continues as an orphan. The old lock file held the Vim PID, which is now dead. The new Neovim instance sees a "stale" lock (dead PID), removes it, and starts a duplicate clone alongside the already-running one.

Fixed with two parts:

1. `mark_installing` writes the Neovim PID atomically via `O_CREAT|O_EXCL` (`"wx"` mode) so two simultaneous instances can't both claim the same lang.
2. Once `compile.clone_repo` starts the git process, the lock file is immediately overwritten with the **git process PID** via a new `on_pid` callback. Now when Neovim exits, the orphaned git process is what keeps the lock alive; `is_installing` checks `vim.uv.kill(pid, 0)` against the git PID, finds it running, and correctly skips the lang on the next startup.

`is_installing` also cleans up genuinely stale locks (git finished or was killed) so a failed install never permanently blocks a lang.

### Contributing factor: unlimited parallelism on fresh install

On a fresh Neovim install with `install_popular = true`, all ~25 parsers kick off simultaneously, each cloning a separate repo. This floods GitHub with connections and makes the stampede problem more likely to be noticed. Added a `concurrency` config option (default `nil` = unlimited, preserving existing behaviour) that caps how many repos are cloned/built in parallel. `install_batch` now uses a semaphore queue internally.

```lua
require("arborist").setup({
  concurrency = 4, -- or 1 for metered connections
})
```

### Testing

The easiest way to test this is run in your terminal:

```bash
watch -n0.1 'ps aux | grep -E "tree-sitter|git clone|git -C" | grep -v grep'
```

Then try to start/restart nvim a couple of times on a fresh install. Compare on `main` vs this branch.

Fixes #12 #9 