### PR TITLE
Install required parser dependencies automatically

### DIFF
--- a/lua/arborist/install.lua
+++ b/lua/arborist/install.lua
@@ -106,6 +106,26 @@ local function build_parser(repo_path, lang, info, opts, callback)
   end
 end
 
+--- Expand a lang list to include all transitive requires deps.
+--- Deps precede their dependents; duplicates are removed.
+--- @param langs string[]
+--- @return string[]
+local function expand_required_dependencies(langs)
+  local seen = {}
+  local result = {}
+  local function add(lang)
+    if seen[lang] then return end
+    seen[lang] = true
+    local info = registry.resolve(lang)
+    if info.requires then
+      for _, dep in ipairs(info.requires) do add(dep) end
+    end
+    result[#result + 1] = lang
+  end
+  for _, lang in ipairs(langs) do add(lang) end
+  return result
+end
+
 --- Install multiple parsers. Groups by repo URL — each repo is cloned once,
 --- then parsers sharing that repo are built sequentially from the same clone.
 --- Repo groups run in parallel.
@@ -114,6 +134,8 @@ end
 --- @param opts? {silent?: boolean}
 function M.install_batch(langs, callback, opts)
   opts = opts or {}
+
+  langs = expand_required_dependencies(langs)
 
   -- Resolve all parsers and group by repo URL
   --- @type table<string, {lang: string, info: arborist.ParserInfo}[]>

--- a/registry/ignore.toml
+++ b/registry/ignore.toml
@@ -29,6 +29,7 @@ filetypes = [
   "snacks_terminal",
   "startuptime",
   "TelescopePrompt",
+  "text",
   "toggleterm",
   "Trouble",
   "undotree",


### PR DESCRIPTION
## Install required parser dependencies automatically

The registry's `requires` field was already parsed from `parsers.toml` and stored in `ParserInfo`, but `install_batch` never consulted it. Parsers with dependencies (such as `php`, which requires `php_only`) would install silently but then fail to work because the dependency was never built.

### Fix

Add `expand_required_dependencies()` in `install.lua`. It walks the `requires` graph transitively, deduplicates langs, and orders dependencies before their dependents. It is called at the top of `install_batch`, so every code path that ends up there (single `install()`, batch startup, `ensure_installed`, `ArboristInstall` command) picks up dependencies automatically with no changes at the call sites.

```lua
-- parsers.toml
[php]
requires = ["php_only"]
```

Before: installing php would build only the php parser, leaving it broken. After: php_only is built first, then php.

Fixes #10 