### PR TITLE
Show per-parser progress during batch install

### DIFF
--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -125,22 +125,32 @@ function M.setup(opts)
     end
 
     if #needed == 0 then return end
-    log.info("Installing parsers...")
+    local total = #needed
+    local done = 0
+    log.info("Installing " .. total .. " parsers...")
     install.install_batch(needed, function(results)
       local failed = {}
       for lang, err in pairs(results) do
         if err then failed[#failed + 1] = lang .. " (" .. err .. ")" end
       end
-      if #failed == 0 then
-        log.info("Parser installation complete")
-      else
+      if #failed > 0 then
         table.sort(failed)
         log.warn("Failed: " .. table.concat(failed, ", "))
       end
       vim.schedule(function()
         for _, l in ipairs(needed) do enable_bufs(l) end
       end)
-    end, { silent = true })
+    end, {
+      silent = true,
+      progress = function(lang, err)
+        done = done + 1
+        if err then
+          log.warn(string.format("[%d/%d] %s failed", done, total, lang))
+        else
+          log.info(string.format("[%d/%d] %s", done, total, lang))
+        end
+      end,
+    })
   end
 
   batch_install()

--- a/lua/arborist/install.lua
+++ b/lua/arborist/install.lua
@@ -159,6 +159,9 @@ function M.install_batch(langs, callback, opts)
         local p = parsers[i]
         build_parser(path, p.lang, p.info, opts, function(build_err)
           results[p.lang] = build_err
+          if opts.progress then
+            opts.progress(p.lang, build_err)
+          end
           build_next(i + 1)
         end)
       end

--- a/registry/ignore.toml
+++ b/registry/ignore.toml
@@ -29,6 +29,7 @@ filetypes = [
   "snacks_terminal",
   "startuptime",
   "TelescopePrompt",
+  "text",
   "toggleterm",
   "Trouble",
   "undotree",


### PR DESCRIPTION
## Show per-parser progress during batch install

On a fresh install with `install_popular = true`, around 25 parsers queue up. The only feedback was `"Installing parsers..."` followed by silence for several minutes, then a final pass/fail summary. There was no way to tell if anything was happening or how far along the install was.

### Changes

**`install.lua`** — `install_batch` opts now accepts a `progress` callback:

```lua
progress?: fun(lang: string, err: string?)
```

Called after each parser build completes (success or failure). Keeping it as a callback in opts rather than always-on logging means callers control whether and how to surface it, and single-parser installs via install.install() stay silent by default.

init.lua: The batch startup path wires up the callback to produce live output:

```
Installing 25 parsers...
[1/25] bash
[2/25] c
[3/25] lua failed
...
```

The total count is now included in the opening message. "Parser installation complete" is removed, as [N/N] lang already signals completion. The failure summary at the end is kept so all
failures are visible in one place if notifications get dismissed.

Closes #11
