### PR TITLE
feat(config): support "all" in ensure_installed to install every parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- **`ensure_installed = "all"`.** Beyond a list of parser names,
+  `ensure_installed` now accepts the sentinel string `"all"`, which expands
+  to every parser in the bundled registry. A new `registry.names()`
+  enumerates the registered parsers and the sentinel is expanded at startup.
 - **Tree-sitter folding** (#19), on by default. For buffers whose language has
   a bundled `folds` query, arborist sets `foldmethod=expr` and `foldexpr` — the
   same way it sets `indentexpr` from an `indents` query — and raises the
@@ -18,6 +22,17 @@ All notable changes to this project will be documented in this file.
   window but never touches `foldenable`.
 
 ### Fixed
+- **A large `ensure_installed` no longer freezes startup.** The startup
+  `batch_install` decided what to install by calling
+  `vim.treesitter.language.add` on every name in the list — and that
+  `dlopen`s each installed parser into memory on the main thread. The more
+  parsers in `ensure_installed`, the longer the synchronous load blocked the
+  UI; `ensure_installed = "all"` was the worst case, loading hundreds of
+  parsers and stalling for seconds, and it defeated lazy loading throughout.
+  A new cheap `install.is_installed` (an `fs_stat` check, no load) now drives
+  the install decision, and tree-sitter is enabled only on already-open
+  buffers rather than across the whole registry. Parsers still load lazily on
+  `FileType`.
 - **Parser installs no longer fail silently** (#18). A `tree-sitter build
   --wasm` that stalls — typically the lazy ~80 MB wasi-sdk download on the
   first WASM build — would hang forever, and because WASM builds are

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All options and their defaults:
 | `update_cadence`   | `"daily"`                         | `"daily"`, `"weekly"`, or `"manual"`                       |
 | `compiler`         | `"cc"`                            | C compiler for native .so builds (string or argv list)     |
 | `install_popular`  | `true`                            | Install popular language parsers at startup                |
-| `ensure_installed` | `{}`                              | Additional parsers to install eagerly at startup           |
+| `ensure_installed` | `{}`                              | Parsers to install eagerly at startup; list of names or `"all"` |
 | `ignore`           | `{}`                              | Extra filetypes to skip (merged with registry defaults)    |
 | `overrides`        | `{}`                              | Extra parsers not in the registry                          |
 | `concurrency`      | `nil`                             | Max repos to clone/build in parallel (`nil` = unlimited)   |
@@ -62,7 +62,17 @@ programming languages, common config/data formats (JSON, YAML, TOML, XML,
 INI, Dockerfile, Makefile), and parsers needed by popular plugins like
 [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)
 (markdown, markdown_inline, html, latex). Set `install_popular = false`
-to disable. Use `ensure_installed` to add parsers beyond the popular set.
+to disable. Use `ensure_installed` to add parsers beyond the popular set —
+either a list of parser names, or the string `"all"` to install every parser
+in the registry up front:
+
+```lua
+require("arborist").setup({
+  ensure_installed = { "go", "rust" }, -- specific parsers
+  -- or
+  ensure_installed = "all",            -- every parser in the registry
+})
+```
 
 **Everything else** installs on demand — open a file and arborist handles
 the rest.

--- a/lua/arborist/config.lua
+++ b/lua/arborist/config.lua
@@ -11,7 +11,7 @@
 --- @field update_cadence "daily"|"weekly"|"manual" Auto-update frequency
 --- @field compiler string|string[] C compiler for native .so builds (string or argv list, e.g. {"zig","cc"})
 --- @field install_popular boolean Install popular language parsers at startup
---- @field ensure_installed string[] Additional parsers to install eagerly at startup
+--- @field ensure_installed "all"|string[] Parsers to install eagerly at startup. A list of parser names, or the string "all" to install every parser in the registry.
 --- @field ignore string[] Extra filetypes to ignore (merged with registry defaults)
 --- @field overrides table<string, {url: string, location?: string}> Extra parser overrides
 --- @field concurrency integer? Max parallel repo installs (nil = unlimited)
@@ -34,6 +34,8 @@ local defaults = {
   -- like render-markdown.nvim. Set to false to disable.
   install_popular = true,
   -- Additional parsers to install eagerly at startup (beyond the popular set).
+  -- A list of parser names, or the string "all" to install every parser in
+  -- the registry.
   ensure_installed = {},
   ignore = {},
   overrides = {},

--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -175,7 +175,15 @@ function M.setup(opts)
       "markdown", "markdown_inline", "python", "regex", "ruby", "rust",
       "toml", "tsx", "typescript", "vim", "vimdoc", "xml", "yaml",
     } or {}
-    vim.list_extend(to_install, config.values.ensure_installed)
+    -- `ensure_installed` is either a list of parser names or the sentinel
+    -- string "all", which expands to every parser in the registry so users
+    -- can opt into installing everything up front.
+    local ensure = config.values.ensure_installed
+    if ensure == "all" then
+      vim.list_extend(to_install, registry.names())
+    else
+      vim.list_extend(to_install, ensure)
+    end
 
     local needed = {}
     for _, lang in ipairs(to_install) do

--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -188,9 +188,25 @@ function M.setup(opts)
     local needed = {}
     for _, lang in ipairs(to_install) do
       if install.should_skip(lang) then -- skip
-      elseif parser_loaded(lang) then enable_bufs(lang)
+      -- is_installed is a cheap fs_stat; parser_loaded would dlopen every
+      -- already-built parser into memory, which costs seconds at startup
+      -- when ensure_installed = "all". Parsers load lazily on FileType.
+      elseif install.is_installed(lang) then
       elseif install.is_installing(lang) then
       else needed[#needed + 1] = lang end
+    end
+
+    -- Enable tree-sitter on buffers already open before setup() ran (FileType
+    -- has already fired for them). Bounded by the number of open buffers, so
+    -- it stays cheap even with the full registry — we only load the handful of
+    -- parsers actually in use, not every installed one.
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_loaded(buf) and vim.bo[buf].buftype == "" then
+        local lang = detect_lang(buf)
+        if lang and not install.should_skip(lang) and install.is_installed(lang) then
+          enable(buf)
+        end
+      end
     end
 
     if #needed == 0 then return end

--- a/lua/arborist/install.lua
+++ b/lua/arborist/install.lua
@@ -94,6 +94,17 @@ function M.should_skip(lang)
   return ignore[lang] or false
 end
 
+--- Is a parser already built on disk? A cheap stat that, unlike
+--- `vim.treesitter.language.add`, does NOT dlopen the parser into memory.
+--- Used to decide what to install without eagerly loading every installed
+--- parser at startup (critical when `ensure_installed = "all"`).
+--- @param lang string
+--- @return boolean
+function M.is_installed(lang)
+  return vim.uv.fs_stat(parser_dir .. "/" .. lang .. ".so") ~= nil
+    or vim.uv.fs_stat(parser_dir .. "/" .. lang .. ".wasm") ~= nil
+end
+
 --- Build a single parser from a cloned repo. Tries WASM first, then native.
 --- @param repo_path string  Cloned repo on disk
 --- @param lang string

--- a/lua/arborist/registry.lua
+++ b/lua/arborist/registry.lua
@@ -190,6 +190,20 @@ function M.has(lang)
   return entries ~= nil and entries[lang] ~= nil
 end
 
+--- Every parser name with an explicit registry entry, sorted. Used to
+--- expand the `"all"` sentinel in `ensure_installed`. Heuristic-only langs
+--- (no registry entry) are not included since they can't be enumerated.
+--- @return string[]
+function M.names()
+  M.load()
+  local out = {}
+  if entries then
+    for lang in pairs(entries) do out[#out + 1] = lang end
+  end
+  table.sort(out)
+  return out
+end
+
 --- Resolve a language to parser info.
 --- Priority: user overrides → bundled registry merged with pins → heuristic.
 --- @param lang string


### PR DESCRIPTION
ensure_installed now accepts either a list of parser names or the string "all", which expands to every parser in the registry. Add registry.names() to enumerate registered parsers and expand the sentinel at startup.