### PR TITLE
Add jsdoc and regex as parser requirements for javascript

### DIFF
--- a/registry/parsers.toml
+++ b/registry/parsers.toml
@@ -563,7 +563,7 @@ maintainers = ["@rmuir"]
 [javascript]
 url = "https://github.com/tree-sitter/tree-sitter-javascript"
 maintainers = ["@steelsojka"]
-requires = ["ecma", "jsx"]
+requires = ["ecma", "jsx", "jsdoc", "regex"]
 
 [jinja]
 url = "https://github.com/cathaysia/tree-sitter-jinja"


### PR DESCRIPTION
Does this mean the jsdoc parser is also installed when a javascript file is opened?