### PR TITLE
Update Slint grammar and highlighting rules

### DIFF
--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -1,4 +1,5 @@
-(comment) @comment @spell
+(line_comment) @comment @spell
+(block_comment) @comment @spell
 
 ; Different types:
 (string_value) @string @spell
@@ -136,20 +137,14 @@
 (binding_alias
   name: (simple_identifier) @property)
 
-(binding
-  name: (simple_identifier) @property)
+(struct_field_definition
+  name: (simple_identifier) @variable.member)
 
-(struct_block
-  (simple_identifier) @variable.member)
-
-(anon_struct_block
-  (simple_identifier) @variable.member)
+(anon_struct_assignment
+  member: (simple_identifier) @variable.member)
 
 (property_assignment
   property: (simple_identifier) @property)
-
-(states_definition
-  name: (simple_identifier) @variable)
 
 (callback
   name: (simple_identifier) @variable)
@@ -168,14 +163,16 @@
   member: (expression
     (simple_identifier) @property))
 
-(states_definition
-  name: (simple_identifier) @constant)
+(state_definition
+  name: (simple_identifier) @constant
+  "when" @keyword)
 
 ; Attributes:
 [
   (linear_gradient_identifier)
   (radial_gradient_identifier)
   (radial_gradient_kind)
+  (conic_gradient_identifier)
 ] @attribute
 
 (image_call
@@ -187,7 +184,14 @@
 ; Keywords:
 (animate_option_identifier) @keyword
 
-(export) @keyword.import
+(export_statement
+  "export" @keyword.import)
+
+(exported_definition
+  "export" @keyword.import)
+
+(export_type
+  "as" @keyword.import)
 
 (if_statement
   "if" @keyword.conditional)
@@ -231,7 +235,7 @@
 (global_definition
   "global" @keyword)
 
-(imperative_block
+(return_statement
   "return" @keyword.return)
 
 (import_statement
@@ -247,10 +251,7 @@
   "property" @keyword)
 
 (states_definition
-  [
-    "states"
-    "when"
-  ] @keyword)
+  "states" @keyword)
 
 (struct_definition
   "struct" @keyword.type)

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -76,6 +76,9 @@
 (function_definition
   name: (_) @function)
 
+(function_declaration
+  name: (_) @function)
+
 (struct_definition
   name: (_) @type)
 
@@ -181,6 +184,21 @@
 (tr
   "@tr" @attribute)
 
+(rust_attr
+  "@rust-attr" @attribute)
+
+(keys
+  "@keys" @attribute)
+
+(markdown
+  "@markdown" @attribute)
+
+(keys
+  (simple_identifier) @constant)
+
+(keys
+  "+" @operator)
+
 ; Keywords:
 (animate_option_identifier) @keyword
 
@@ -211,14 +229,23 @@
 (animate_statement
   "animate" @keyword)
 
+(gradient_call
+  [
+    "at"
+    "from"
+  ] @keyword)
+
 (callback
   "callback" @keyword)
 
+(changed_event
+  "changed" @keyword)
+
 (component_definition
-  [
-    "component"
-    "inherits"
-  ] @keyword)
+  "component" @keyword)
+
+(component_modifier
+  "inherits" @keyword)
 
 (enum_definition
   "enum" @keyword.type)
@@ -232,8 +259,16 @@
 (function_definition
   "function" @keyword.function)
 
+(function_declaration
+  "function" @keyword.function)
+
 (global_definition
   "global" @keyword)
+
+(let_statement
+  "let" @keyword
+  name: (_) @variable
+  "=" @operator)
 
 (return_statement
   "return" @keyword.return)
@@ -255,6 +290,16 @@
 
 (struct_definition
   "struct" @keyword.type)
+
+(uses_clause
+  "uses" @keyword)
+
+(used_interface
+  "from" @keyword.import
+  source: (_) @variable)
+
+(implements_clause
+  "implements" @keyword)
 
 (transitions_definition
   [

--- a/queries/slint/injections.scm
+++ b/queries/slint/injections.scm
@@ -1,2 +1,2 @@
-((comment) @injection.content
+([(line_comment) (block_comment)] @injection.content
   (#set! injection.language "comment"))

--- a/queries/slint/locals.scm
+++ b/queries/slint/locals.scm
@@ -114,4 +114,4 @@
   (#set! reference.kind "type"))
 
 (unary_expression
-  left: (_) @local.reference)
+  expr: (_) @local.reference)

--- a/registry/parsers.toml
+++ b/registry/parsers.toml
@@ -1064,7 +1064,7 @@ maintainers = ["@theoo"]
 
 [slint]
 url = "https://github.com/slint-ui/tree-sitter-slint"
-maintainers = ["@hunger"]
+maintainers = ["@LeonMatthes"]
 
 [smali]
 url = "https://github.com/tree-sitter-grammars/tree-sitter-smali"

--- a/registry/pins.toml
+++ b/registry/pins.toml
@@ -754,7 +754,7 @@ revision = "1dbcc4abc7b3cdd663eb03d93031167d6ed19f56"
 revision = "a06113f5175b805a37d20df0a6f9d722e0ab6cfe"
 
 [slint]
-revision = "4d7ad0617c30f865f051bbac04a9826bea29f987"
+revision = "f94f96ce093ec153f037228ac2fac5f1a3cd9ac6"
 
 [smali]
 revision = "fdfa6a1febc43c7467aa7e937b87b607956f2346"


### PR DESCRIPTION
The Tree-sitter grammar in Slint was recently updated and this patch contains the corresponding updates to the highlights rule and the updated Tree-sitter grammar repository hash.

I also added myself as the maintainer. I am a developer at Slint and have taken over maintaining most of the work by `@hunger`.