### PR TITLE
feat(config): add automatic_install option for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,18 @@ require("arborist").setup({
 
 All options and their defaults:
 
-| Option             | Default                           | Description                                                |
-| ------------------ | --------------------------------- | ---------------------------------------------------------- |
-| `prefer_wasm`      | `true`                            | Try WASM before native compilation                         |
-| `update_cadence`   | `"daily"`                         | `"daily"`, `"weekly"`, or `"manual"`                       |
-| `compiler`         | `"cc"`                            | C compiler for native .so builds (string or argv list)     |
-| `install_popular`  | `true`                            | Install popular language parsers at startup                |
-| `ensure_installed` | `{}`                              | Additional parsers to install eagerly at startup           |
-| `ignore`           | `{}`                              | Extra filetypes to skip (merged with registry defaults)    |
-| `overrides`        | `{}`                              | Extra parsers not in the registry                          |
-| `concurrency`      | `nil`                             | Max repos to clone/build in parallel (`nil` = unlimited)   |
-| `disable`          | `{ highlight = {}, indent = {} }` | Per-lang opt-out for tree-sitter highlight or indent       |
+| Option               | Default                           | Description                                                  |
+| -------------------- | --------------------------------- | ------------------------------------------------------------ |
+| `automatic_install`  | `true`                            | Auto-install parsers when opening files with missing parsers |
+| `prefer_wasm`        | `true`                            | Try WASM before native compilation                           |
+| `update_cadence`     | `"daily"`                         | `"daily"`, `"weekly"`, or `"manual"`                         |
+| `compiler`           | `"cc"`                            | C compiler for native .so builds (string or argv list)       |
+| `install_popular`    | `true`                            | Install popular language parsers at startup                  |
+| `ensure_installed`   | `{}`                              | Additional parsers to install eagerly at startup             |
+| `ignore`             | `{}`                              | Extra filetypes to skip (merged with registry defaults)      |
+| `overrides`          | `{}`                              | Extra parsers not in the registry                            |
+| `concurrency`        | `nil`                             | Max repos to clone/build in parallel (`nil` = unlimited)     |
+| `disable`            | `{ highlight = {}, indent = {} }` | Per-lang opt-out for tree-sitter highlight or indent         |
 
 `disable` example — turn off TS indent for markdown and TS highlight for csv:
 
@@ -65,7 +66,9 @@ INI, Dockerfile, Makefile), and parsers needed by popular plugins like
 to disable. Use `ensure_installed` to add parsers beyond the popular set.
 
 **Everything else** installs on demand — open a file and arborist handles
-the rest.
+the rest. Set `automatic_install = false` to disable on-demand installation
+entirely; parsers from `install_popular` and `ensure_installed` are still
+installed, and `:ArboristInstall` remains available for manual installs.
 
 ## How It Works
 

--- a/lua/arborist/config.lua
+++ b/lua/arborist/config.lua
@@ -5,6 +5,7 @@
 --- @field indent? string[] Langs to skip indentexpr setup on (uses Vim default)
 
 --- @class arborist.Config
+--- @field automatic_install boolean Auto-install parsers when opening files with missing parsers
 --- @field prefer_wasm boolean Try WASM before native compilation
 --- @field update_cadence "daily"|"weekly"|"manual" Auto-update frequency
 --- @field compiler string|string[] C compiler for native .so builds (string or argv list, e.g. {"zig","cc"})
@@ -17,6 +18,7 @@
 
 --- @type arborist.Config
 local defaults = {
+  automatic_install = true,
   prefer_wasm = true,
   update_cadence = "daily",
   compiler = vim.env.CC or "cc",

--- a/lua/arborist/init.lua
+++ b/lua/arborist/init.lua
@@ -106,6 +106,7 @@ function M.setup(opts)
   local function ensure_parser(lang)
     if install.should_skip(lang) then return end
     if parser_loaded(lang) then enable_bufs(lang); return end
+    if not config.values.automatic_install then return end
     if ensuring[lang] then return end
     -- Cross-actor guard: another batch_install or another Neovim instance
     -- is already on it. Stay silent so we don't double-notify.


### PR DESCRIPTION
`automatic_install` config option (default `true`) that controls whether parsers are installed on demand when opening files with missing parsers.

When using this I've noticed parsers building with clang quite often hogging my cpu resources.
I'd prefer an opt-in workflow for this. While disabling for certain languages works, I don't know in advance which files I open sometimes.

Closes #29 